### PR TITLE
Use glob match properly to get only HTML & JS (#6)

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -36,7 +36,7 @@ const matilda = `
         console.log(`Copy:  ${chalk.magentaBright`/static`} => ${chalk.magentaBright`/public`}`)
         await fs.copy(paths.static, paths.public);
 
-        const files = await recursive(paths.content, ['.html', '.js']);
+        const files = await recursive(paths.content, ['!*.{html,js}']);
 
         const templates = await Promise.all([
             fs.readFile(path.join(paths.templates, 'header.html'), 'utf8'),

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
   "dependencies": {
     "chalk": "^4.1.0",
     "fs-extra": "^9.0.1",
-    "glob": "^7.1.6",
     "recursive-readdir": "^2.2.2",
     "rimraf": "^3.0.2"
   }


### PR DESCRIPTION
Also removed the `glob` package, as never actually used it directly.