### PR TITLE
Use 1 template instead of header/footer (#4)

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -38,16 +38,13 @@ const matilda = `
 
         const files = await recursive(paths.content, ['!*.{html,js}']);
 
-        const templates = await Promise.all([
-            fs.readFile(path.join(paths.templates, 'header.html'), 'utf8'),
-            fs.readFile(path.join(paths.templates, 'footer.html'), 'utf8')
-        ]);
+        const template = await fs.readFile(path.join(paths.templates, 'index.html'), 'utf8');
 
         await Promise.all(files.map(async file => {
             console.log(`Read:  ${chalk.greenBright`${file.replace(paths.root, '')}`}`);
             const content = file.endsWith('.js') ? await require(file)(file) : await fs.readFile(file, 'utf8');
             const publicPath = calculatePublicPath(file);
-            fs.outputFile(path.join(paths.public, publicPath), `${templates[0]}\n${content}\n${templates[1]}`);
+            fs.outputFile(path.join(paths.public, publicPath), template.replace(/{{\W?main\W?}}/, content));
             console.log(`Write: ${chalk.blueBright`/public/${publicPath}`}`);
         }));
 

--- a/templates/footer.html
+++ b/templates/footer.html
@@ -1,8 +1,0 @@
-    </main>
-
-    <footer role="contentinfo">
-        Footer.
-    </footer>
-
-</body>
-</html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -16,3 +16,12 @@
     </header>
 
     <main role="main">
+    	{{ main }}
+    </main>
+
+    <footer role="contentinfo">
+        Footer.
+    </footer>
+
+</body>
+</html>


### PR DESCRIPTION
Instead of `header.html` and `footer.html` which doesn't work well in editors with prettier and similar, let's just use 1 template file and inject in the content.

Fixes #3 
Fixes #4 