### PR TITLE
Write 404 pages to `/404.html` (#21)

### DIFF
--- a/bin/matilda
+++ b/bin/matilda
@@ -31,7 +31,9 @@ const calculatePublicPath = (file) => {
         new RegExp(`${paths.content}/(.+)(?:\.js|\.html)$`),
         "$1"
     );
-    return path.join(slug === "index" ? "" : slug, "index.html");
+    return slug === "404"
+        ? "404.html"
+        : path.join(slug === "index" ? "" : slug, "index.html");
 };
 
 const calculateContentPathFromRequest = (p) => {


### PR DESCRIPTION
Fixes #21 

Matilda used to build 404 pages to `/404/index.html` but it's more common for a provider to use `/404.html` by default.